### PR TITLE
Fixed grammar on line 872

### DIFF
--- a/README
+++ b/README
@@ -869,7 +869,7 @@ Open MPI Extensions
     operations and persistent neighborhood collective communication
     operations, which are planned to be included in the next MPI
     Standard after MPI-3.1 as of Nov. 2018.  The function names are
-    prefixed with MPIX_ instead of MPI_, like MPIX_Barrier_init,
+    prefixed with MPIX_ instead of MPI_ (e.g., MPIX_Barrier_init)
     because they are not standardized yet.  Future versions of Open MPI
     will switch to the MPI_ prefix once the MPI Standard which includes
     this feature is published.  See their man page for more details.


### PR DESCRIPTION
'prefixed with MPIX_ instead of MPI_ , MPIX_Barrier_init,' ->
'prefixed with MPIX_ instead of MPI_ (e.g., MPIX_Barrier_init)'

Signed-off-by: wggillen <gillenwg@gmail.com>

#hacktoberfest